### PR TITLE
Update 0woerterbuch.csv

### DIFF
--- a/chapters/0woerterbuch.csv
+++ b/chapters/0woerterbuch.csv
@@ -1,33 +1,32 @@
 x/o,EN,DE
 x,aftermath,Nachwirkungen -> Nachspiel 
-x,Ancient House,Uraltes Hause
-x,Noble and Most Ancient House,Edle und Uralte Haus
-x,Noble and Most Ancient House,Edlen und Uralten Hauses
+x,Ancient House,Altes Geschlecht
+x,Noble and Most Ancient House,Altehrwürdiges Geschlecht
 ,betrayed,hintergangen (Kaptiel 100++)
-x,Boy-Who-Lived,Junge-der-lebte
+x,Boy-Who-Lived,Junge-der-überlebte
 ,broomstick team,Besenteam
 ,Chaos Legion,Chaoslegion
 ,Chaos Legionnaires,Chaoslegionäre
-,Chief Warlock,?Oberste Hexenmeister/Großmeister
-,Cloak of Invisibility,Unsichtbarkeitsumhang
-,invisibility cloak,Unsichtbarkeitsumhang
-x,comed-tea,Comed-Tea(/Seltsaft/Poin-Tee)
+,Chief Warlock,Großmeister
+,Cloak of Invisibility,Tarnumhang
+,invisibility cloak,Tarnumhang
+x,comed-tea,Seltsaft
 x,dad,Dad (Papa)
-,Daily Prophet,Tagespropheten
+,Daily Prophet,Tagesprophet
 ,Death Eater,Todesser
 ,Defence Professor,Verteidigungsprofessor
 ,Professor der Verteidigung,Verteidigungsprofessor
 ,Dragon General,Drachengeneral
 ,England,Britannien
-,Floo,Floh?
-,first-aid kit, Erste-Hilfe-Kasten/Notfall-Heilpack Plus 
+,Floo,Floh
+,first-aid kit, Erste-Hilfe-Kasten
 ,foolishness, Torheit
 x,führnehmen,Edlen
-x,He-Who-Must-Not-Be-Named,Er-dessen-Name-nicht-genannt-werden-darf (Du-weißt-schon-wem)
+x,He-Who-Must-Not-Be-Named,Er-dessen-Name-nicht-genannt-werden-darf (Du-weißt-schon-wer)
 ,Herr Potter,Mr Potter
-x,headmaster,Direktor -> Schulleiter
+x,headmaster,Schulleiter
 ,life-eater,Lebensfresser
-,Mary’s Place, ? Marys Platz
+,Mary’s Place, Marys
 x,Macmillian,Macmillan
 ,Most Ancient, Uralt
 ,Most Ancient Hall,Ältestenhalle
@@ -43,11 +42,11 @@ x,mum, Mum(Mama/Mutter)
 x,plaque,Plakette(NICHT Schallplatte)
 ,pop(s),? (Apperation)
 ,Potions Master, Zaubertränkemeister
-,robe, ? Robe / Umgang
+,robe, ? Robe / Umhang
 ,sense of doom,Unheilsgefühl (nicht: Gefühl der Verdammnis? Gefühl des Untergangs? Gefühl des Unheils)
 x,S.P.H.E.W.,\SPHEW
-,Sunshine General,Sonnenschein-Generalin
-,Time-Turner,?Zeitumkehrer
+,Sunshine General,Sonnenschein-General
+,Time-Turner,Zeitumkehrer
 ,Forbidden Forest,Verbotener Wald
 ,wand,Zauberstab
 x,You-Know-Who,Du-weißt-schon-wer
@@ -61,7 +60,7 @@ x,You-Know-Who,Du-weißt-schon-wer
 ,Horcrux,Horkrux
 ,Imperius,Imperius
 ,Innervate,Rennervate
-,Killing Curse,Tötungsfluch
+,Killing Curse,Todesfluch
 ,Legilimency,Legilimentik
 ,Luminos,Luminos
 ,Memory Charm,Gedächtniszauber
@@ -72,9 +71,9 @@ x,You-Know-Who,Du-weißt-schon-wer
 ,Polyfluis Reverso,Polyfluis Reverso
 ,Polyjuice,Vielsafttrank
 ,Obliviation/Obliviating,Vergessenszauber
-,Obliviate,Oblivieren
+,Obliviate,Obliviieren
 ,Quieting Charm,Stillezauber
-,Severing Charm,Durchtrennungszauber
+,Severing Charm,Trennungszauber
 ,Shield Charm, Schildzauber
 ,Stupefy,Stupor
 ,Stunning Hex,Betäubungszauber

--- a/chapters/0woerterbuch.csv
+++ b/chapters/0woerterbuch.csv
@@ -1,16 +1,16 @@
 x/o,EN,DE
 x,aftermath,Nachwirkungen -> Nachspiel 
-x,Ancient House,Altes Geschlecht
-x,Noble and Most Ancient House,Altehrwürdiges Geschlecht
+,Ancient House,Altes Geschlecht
+,Noble and Most Ancient House,Altehrwürdiges Geschlecht
 ,betrayed,hintergangen (Kaptiel 100++)
-x,Boy-Who-Lived,Junge-der-überlebte
+,Boy-Who-Lived,Junge-der-überlebte
 ,broomstick team,Besenteam
 ,Chaos Legion,Chaoslegion
 ,Chaos Legionnaires,Chaoslegionäre
 ,Chief Warlock,Großmeister
 ,Cloak of Invisibility,Tarnumhang
 ,invisibility cloak,Tarnumhang
-x,comed-tea,Seltsaft
+,comed-tea,Seltsaft
 x,dad,Dad (Papa)
 ,Daily Prophet,Tagesprophet
 ,Death Eater,Todesser
@@ -24,7 +24,7 @@ x,dad,Dad (Papa)
 x,führnehmen,Edlen
 x,He-Who-Must-Not-Be-Named,Er-dessen-Name-nicht-genannt-werden-darf (Du-weißt-schon-wer)
 ,Herr Potter,Mr Potter
-x,headmaster,Schulleiter
+,headmaster,Schulleiter
 ,life-eater,Lebensfresser
 ,Mary’s Place, Marys
 x,Macmillian,Macmillan
@@ -40,7 +40,7 @@ x,mum, Mum(Mama/Mutter)
 ,phœnix,Phönix
 ,phœnixes,Phönixe
 x,plaque,Plakette(NICHT Schallplatte)
-,pop(s),? (Apperation)
+,pop(s),Plop (Apperation)
 ,Potions Master, Zaubertränkemeister
 ,robe, ? Robe / Umhang
 ,sense of doom,Unheilsgefühl (nicht: Gefühl der Verdammnis? Gefühl des Untergangs? Gefühl des Unheils)


### PR DESCRIPTION
Hier mal eine gewisse Vorschlagsliste. Da ist einiges dabei, am strittigsten sicher die Geschichte mit dem "Noble and Most Ancient House". Eine längere Recherche hat mich zu dem Schluss gebracht, dass es "House of" im Deutschen nicht als "Haus" gibt. Beim Adel gibt es z.B. auf der englischen Wikipedia eine lange Liste deutscher Geschlechter, die dort als "Houses" tituliert sind, auch in den Einzelartikeln. Im Deutschen Wiki ist hier hingegen stets von "Geschlechtern" die Rede.
Da mMn. im Originaltext hier der Eindruck des Mittelalters verstärkt werden sollte, bin ich also auf die eheste deutsche Entsprechung gegangen. Weckt aus meiner Sicht auch (passende) unangenehme Assoziationen mit Rückständigkeit, Fokus auf Abstammung, Erblehre usw. usf.
"Moke" ist scheinbar ein uraltes Wort für Esel, aber ich habe kein entsprechend altes deutsches gefunden. "Asinusfellbeutel" wäre noch möglich, ist halt latein. Hat mir aber nicht gefallen^^
"Generalin"->"General", mWn werden militärische Ränge auf deutsch nicht dem Geschlecht des Rangträgers angepasst, sondern ggf. beim Ansprechen ein "Frau" davorgestellt, d.h. "Frau General" statt "Generalin"/"Generälin".
Was noch offen ist, aus meiner Sicht: "To crucio"/"to crucify" im Sinne von "Den Cruciatus-Fluch benutzen". Das war glaube ich in den Originalbüchern kein Verb. Schneefl0cke nutzt einfach "foltern" als Umschreibung, und ich frage mich, ob es da noch eine elegantere Lösung geben könnte. Ist mir aber noch nicht eingefallen...