### PR TITLE
Update 0woerterbuch.csv

### DIFF
--- a/chapters/0woerterbuch.csv
+++ b/chapters/0woerterbuch.csv
@@ -21,7 +21,7 @@ x,Professor der Verteidigung,Verteidigungsprofessor
 x,Dragon General,Drachen-General
 x,England,Britannien
 ,Floo,Floh
-,first-aid kit, Erste-Hilfe-Kasten
+,first-aid kit, Erste-Hilfe-Tasche
 x,foolishness, Torheit
 x,führnehmen,Edlen
 x,He-Who-Must-Not-Be-Named,Er-dessen-Name-nicht-genannt-werden-darf (Du-weißt-schon-wer)
@@ -29,20 +29,20 @@ x,Headmaster,Schulleiter
 x,life-eater,Lebensfresser
 x,Mary’s Place, Marys Stube
 x,Macmillian,Macmillan
-x,Most Ancient, Uralt
-x,Most Ancient Hall,Ältestenhalle
+x,Most Ancient, Altehrwürdig
+x,Most Ancient Hall, Alterwürdige Halle
 x,mum, Mum(Mama/Mutter)
 x,N.E.W.T,U.T.Z.
 x,O.W.L.,Z.A.G.
 x,Patronus Charm,Patronus-Zauber
 x,Parseltongue,Parsel
-,PC,Spielercharakter
-,NPC,Nicht-Spielercharakter
+,PC,SC
+,NPC,NSC
 ,phœnix,Phönix
 ,phœnixes,Phönixe
 x,plaque,Plakette(NICHT Schallplatte)
 ,pop(s),Plop (Apperation)
-x,Potions Master, Zaubertränkemeister
+x,Potions Master,Meister der Zaubertränke
 x,Quibbler,Klitterer
 x,robe, Umhang / Zaubererumhang
 x,sense of doom,Unheilsgefühl
@@ -108,8 +108,8 @@ s,Lumos,
 s,Mahasu,
 ,Memory Charm,Gedächtniszauber
 ,False Memory Charm,Falsche-Erinnerung-Zauber
-,Most Ancient Blade, Uralte Klinge
-,Charn of the Most Ancient Blade, Zauber der Uralten Klinge
+,Most Ancient Blade, Altehrwürdige Klinge
+,Charn of the Most Ancient Blade, Zauber der Alterwürdigen Klinge
 s,Prismatis,
 s,Polyfluis Reverso,
 ,Polyjuice,Vielsafttrank
@@ -120,7 +120,7 @@ s,Protego,
 s,Quietus,Geräuschdämpfer
 ,Quieting Charm,Stillezauber
 s,Ravum Calvaria,
-,Severing Charm,Trennungszauber
+,Severing Charm,Durchtrennungszauber
 s,Scourgify,Ratzeputz
 ,Shield Charm, Schildzauber
 s,Silencio,


### PR DESCRIPTION
Zuerst ein paar Anmerkungen, wo ich nix angepasst habe, aber evtl. einer Diskussion würdig sind: robe: Im Deutschen wurde 'robe' mit Umhang übersetzt. Persönlich finde ich das die falsche Übersetzung, da einerseits "A robe was distinguished from a cape or cloak by the fact that it usually had sleeves." dieser Unterschied wegfällt (vgl. Tarnumhang) und andererseits das Wort Robe laut Wikipedia durchaus das beschreibt, was in den Büchern getragen wird ("Der Begriff Robe bezeichnet festlich-gravitätische Kleidungsstücke von sehr unterschiedlicher Form und Zweckbestimmung, darunter insbesondere die weiten, mantelartigen Gewänder, die in vielen Staaten der Welt als Amtstracht von Juristen, Hochschullehrern und Klerikern getragen werden.") -> Ich bin für 'Robe' anstelle von 'Umhang' bei der 'robe'-Übersetzung 😄 Hermine: Das HP-Lexikon tut es gut erklären (https://harry-potter.fandom.com/de/wiki/Hermine_Granger#Name). Finde ich sehr schade, dass das in der deutschen Übersetzung verloren ging ("Die Absicht der Autorin, der Freundin von Harry und Ron einen ausgefallenen Namen zu geben, ist in der deutschen Ausgabe einer Namensübersetzung zum Opfer gefallen: der extravagante Name wurde eingedeutscht in das etwas altbacken klingende „Hermine“.") Da Elizer die HP-Welt teilweise ernster nahm als die Autorin selber, wäre es zu weit aus dem Fenster gelehnt, wenn wir das mit der Übersetzung ebenso machen würden? (Merkt man, dass ich Fan vom Englischen Namen Hermione bin? 😅) 49: Sollte das nicht BELFER sein? Im Buch scheint es dann zwar richtig zu sein 🙂


24: Kasten wäre ja Box, Tasche passte besser (auch in einer Beschreibung später)
32: Analog zu 'Ancient House'
33: ditto
39: Für alle Spieler unter uns darf auch die korrekte deutsche Bezeichnung nicht fehlen. Mache auch gerne einen Vermerk bei der ersten Erwähnung, was es bedeutet, aber diese Abkürzungen sind zumindest bei uns verbreitet ;-)
40: ditto
45: In der offiziellen Übersetzung ist dieser Begriff uneinheitlich übersetzt worden, aber immer nach dem selben Muster: Meister der Zaubertränke, Experte für Zaubertränke, Lehrer für Zaubertränke.
111: Analog zu 'Ancient House'
112: ditto
123: Umschreibts mE besser. Alternativ evtl. Abtrennungszauber