### PR TITLE
Update hpmor-chapter-001.tex

### DIFF
--- a/chapters/hpmor-chapter-001.tex
+++ b/chapters/hpmor-chapter-001.tex
@@ -44,7 +44,7 @@ Der Professor und seine Frau reden in scharfem Ton miteinander, schreien jedoch 
 „Sie waren auf unserer Hochzeit — sie haben uns zu Weihnachten besucht …“
 
 % “I told them you weren’t to know,” Petunia whispered. “But it’s true. I’ve seen things—”
-„Ich wollte nicht, dass du es erfährst“, flüsterte Petunia. „Aber es ist wahr. Ich habe Sachen gesehen …“
+„Ich wollte nicht, dass du es erfährst“, flüsterte Petunia, „aber es ist wahr. Ich habe Sachen gesehen …“
 
 % The Professor rolled his eyes. “Dear, I understand that you’re not familiar with the sceptical literature. You may not realise how easy it is for a trained magician to fake the seemingly impossible. Remember how I taught Harry to bend spoons? If it seemed like they could always guess what you were thinking, that’s called cold reading—”
 Der Professor verdrehte seine Augen.

--- a/chapters/hpmor-chapter-001.tex
+++ b/chapters/hpmor-chapter-001.tex
@@ -9,15 +9,15 @@
 \begin{chapterOpeningQuote}
 \noindent
 % Beneath the moonlight glints a tiny fragment of silver, a fraction of a line…
-Unter dem Mondlicht schimmerte ein winziges Silberfragment, eine zarte Linie…
+Unter dem Mondlicht schimmerte ein winziges Silberfragment, eine zarte Linie …
 
 \vspace*{2ex}
 % (black robes, falling)
-…schwarze Umhänge fallen…
+… schwarze Umhänge fallen …
 
 \vspace*{2ex}
 % …blood spills out in litres, and someone screams a word.
-…Blut fließt in Strömen und jemand schreit ein Wort.
+… Blut fließt in Strömen und jemand schreit ein Wort.
 \end{chapterOpeningQuote}
 
 % \lettrine{E}{very} inch of wall space is covered by a bookcase. Each bookcase has six shelves, going almost to the ceiling. Some bookshelves are stacked to the brim with hardback books: science, maths, history, and everything else. Other shelves have two layers of paperback science fiction, with the back layer of books propped up on old tissue boxes\footnotemark{} or lengths of wood, so that you can see the back layer of books above the books in front. And it still isn’t enough. Books are overflowing onto the tables and the sofas and making little heaps under the windows.
@@ -37,49 +37,49 @@ Der Professor und seine Frau reden in scharfem Ton miteinander, schreien jedoch 
 „Du machst Witze“, sagte Michael zu Petunia. Sein Tonfall ließ vermuten, wie sehr er fürchtete, dass es ihr Ernst war.
 
 % “My sister was a witch,” Petunia repeated. She looked frightened, but stood her ground. “Her husband was a wizard.”
-„Meine Schwester war eine Hexe“, wiederholte Petunia. Sie sah ängstlich aus, blieb aber standhaft. „ihr Mann war ein Zauberer.“
+„Meine Schwester war eine Hexe“, wiederholte Petunia. Sie sah ängstlich aus, blieb aber standhaft. „Ihr Mann war ein Zauberer.“
 
 % “This is absurd!” Michael said sharply. “They were at our wedding—they visited for Christmas—”
 „Das ist absurd!“, sagte Michael scharf.
-„Sie waren auf unserer Hochzeit—sie haben uns zu Weihnachten besucht…“
+„Sie waren auf unserer Hochzeit — sie haben uns zu Weihnachten besucht …“
 
 % “I told them you weren’t to know,” Petunia whispered. “But it’s true. I’ve seen things—”
-„Ich wollte nicht, dass du es erfährst“, flüsterte Petunia. „aber es ist wahr. Ich habe Sachen gesehen…“
+„Ich wollte nicht, dass du es erfährst“, flüsterte Petunia. „Aber es ist wahr. Ich habe Sachen gesehen …“
 
 % The Professor rolled his eyes. “Dear, I understand that you’re not familiar with the sceptical literature. You may not realise how easy it is for a trained magician to fake the seemingly impossible. Remember how I taught Harry to bend spoons? If it seemed like they could always guess what you were thinking, that’s called cold reading—”
 Der Professor verdrehte seine Augen.
-„Liebling, ich weiß, dass du mit dem Skeptizismus nicht vertraut bist. Es mag dir nicht klar sein, wie leicht es einem erfahrenen Magier fällt, das scheinbar Unmögliche vorzutäuschen. Erinnerst du dich, wie ich Harry beigebracht habe, Löffel zu verbiegen? Wenn es so erschien, als ob sie immer ahnen konnten, was du gerade dachtest—diese Technik nennt sich kalte Deutung oder cold reading—“%
+„Liebling, ich weiß, dass du mit dem Skeptizismus nicht vertraut bist. Es mag dir nicht klar sein, wie leicht es einem erfahrenen Magier fällt, das scheinbar Unmögliche vorzutäuschen. Erinnerst du dich, wie ich Harry beigebracht habe, Löffel zu verbiegen? Wenn es so erschien, als ob sie immer ahnen konnten, was du gerade dachtest — diese Technik nennt sich kalte Deutung oder cold reading …“%
 \translatorsnote{Cold Reading ist ein Fachausdruck für verschiedene Techniken und wird häufig von Zauberkünstlern, insbesondere Mentalisten, aber auch Wahrsagern und ‚Lebensberatern‘ verwendet und eingesetzt (manchmal bewusst, manchmal unbewusst). Ziel ist es in Unterhaltungen den Eindruck zu erwecken, man hätte Wissen zu einer Person, obschon dem nicht so ist. \url{https://de.wikipedia.org/wiki/Cold_Reading}}
 
 % “It wasn’t bending spoons—”
-„Es war kein Löffelverbiegen—“
+„Es war kein Löffelverbiegen …“
 
 % “What was it, then?”
 „Was war es dann?“
 
 % Petunia bit her lip. “I can’t just tell you. You’ll think I’m—” She swallowed. “Listen. Michael. I wasn’t—always like this—” She gestured at herself, as though to indicate her lithe form. “Lily did this. Because I—because I \emph{begged} her. For years, I begged her. Lily had \emph{always} been prettier than me, and I’d…been mean to her, because of that, and then she got \emph{magic,} can you imagine how I felt? And I \emph{begged} her to use some of that magic on me so that I could be pretty too, even if I couldn’t have her magic, at least I could be pretty.”
 Petunia biss sich auf die Lippen.
-„Ich kann es dir nicht einfach erzählen. Du würdest mich—“ Sie schluckte.
-„Also. Michael. Ich war nicht—nicht immer so…“ Sie zeigte auf sich selbst, als ob sie auf ihren wohlgeformten Körper deuten wollte.
-„Lily hat das getan. Weil ich—weil ich sie \emph{angefleht} habe. Jahrelang habe ich sie angefleht. Lily war \emph{immer} schöner als ich und ich…ich war gemein zu ihr, deswegen, und dann konnte sie \emph{zaubern}, kannst du dir vorstellen, wie ich mich gefühlt habe? Und ich habe sie \emph{angefleht}, ein bisschen Magie auf mich anzuwenden, damit ich auch hübsch wäre, selbst wenn ich nicht zaubern konnte, so könnte ich wenigstens hübsch sein.“
+„Ich kann es dir nicht einfach erzählen. Du würdest mich …“ Sie schluckte.
+„Also. Michael. Ich war nicht … nicht immer so …“ Sie zeigte auf sich selbst, als ob sie auf ihren wohlgeformten Körper deuten wollte.
+„Lily hat das getan. Weil ich … weil ich sie \emph{angefleht} habe. Jahrelang habe ich sie angefleht. Lily war \emph{immer} schöner als ich und ich … ich war gemein zu ihr, deswegen, und dann konnte sie \emph{zaubern}, kannst du dir vorstellen, wie ich mich gefühlt habe? Und ich habe sie \emph{angefleht}, ein bisschen Magie auf mich anzuwenden, damit ich auch hübsch wäre, selbst wenn ich nicht zaubern konnte, so könnte ich wenigstens hübsch sein.“
 
 % Tears were gathering in Petunia’s eyes.
 Tränen sammelten sich in Petunias Augen.
 
 % “And Lily would tell me no, and make up the most ridiculous excuses, like the world would end if she were nice to her sister, or a centaur told her not to—the most ridiculous things, and I hated her for it. And when I had just graduated from university, I was going out with this boy, Vernon Dursley, he was fat and he was the only boy who would talk to me. And he said he wanted children, and that his first son would be named Dudley. And I thought to myself, \emph{what kind of parent names their child Dudley Dursley?} It was like I saw my whole future life stretching out in front of me, and I couldn’t stand it. And I wrote to my sister and told her that if she didn’t help me I’d rather just—”
-„Und Lily weigerte sich immer und dachte sich die lächerlichsten Ausreden aus; dass die Welt untergehen würde, wenn sie nett zu ihrer Schwester wäre oder dass ein Zentaur es ihr verboten hatte—die lächerlichsten Dinge und dafür hasste ich sie. Und als ich gerade meinen Abschluss hatte, ging ich mit diesem Jungen aus, Vernon Dursley, er war dick und der einzige Junge, der auf dem College mit mir sprach. Er sagte, er wolle Kinder haben und sein erster Sohn würde Dudley heißen. Und ich dachte mir, \emph{was für Eltern nennen ihr Kind Dudley Dursley?} Es war, als ob ich meine ganze Zukunft klar vor mir sehen würde und ich konnte es nicht ertragen. Und ich schrieb meiner Schwester und teilte ihr mit, wenn sie mir nicht helfen würde, dann würde ich einfach…“
+„Und Lily weigerte sich immer und dachte sich die lächerlichsten Ausreden aus; dass die Welt untergehen würde, wenn sie nett zu ihrer Schwester wäre oder dass ein Zentaur es ihr verboten hatte — die lächerlichsten Dinge und dafür hasste ich sie. Und als ich gerade meinen Abschluss hatte, ging ich mit diesem Jungen aus, Vernon Dursley, er war dick und der einzige Junge, der auf dem College mit mir sprach. Er sagte, er wolle Kinder haben und sein erster Sohn würde Dudley heißen. Und ich dachte mir, \emph{was für Eltern nennen ihr Kind Dudley Dursley?} Es war, als ob ich meine ganze Zukunft klar vor mir sehen würde und ich konnte es nicht ertragen. Und ich schrieb meiner Schwester und teilte ihr mit, wenn sie mir nicht helfen würde, dann würde ich einfach …“
 
 % Petunia stopped.
 Petunia brach ab.
 
 % “Anyway,” Petunia said, her voice small, “she gave in. She told me it was dangerous, and I said I didn’t care any more, and I drank this potion and I was sick for weeks, but when I got better my skin cleared up and I finally filled out and…I was beautiful, people were \emph{nice} to me,” her voice broke, “and after that I couldn’t hate my sister any more, especially when I learned what her magic brought her in the end—”
-„Auf jeden Fall“, sagte Petunia mit schwacher Stimme, „gab sie nach. Sie erzählte mir, dass es gefährlich wäre, und ich sagte ihr, dass mich das nicht interessierte und nahm diesen Zaubertrank und war wochenlang krank, aber als es mir wieder besser ging, wurde meine Haut rein und mein Körper formte sich und…ich war schön, die Leute waren \emph{nett} zu mir“, ihre Stimme gab nach, „und danach konnte ich meine Schwester nicht mehr hassen, besonders nachdem ich hörte, was die Magie ihr am Ende angetan hatte…“
+„Auf jeden Fall“, sagte Petunia mit schwacher Stimme, „gab sie nach. Sie erzählte mir, dass es gefährlich wäre, und ich sagte ihr, dass mich das nicht interessierte, und nahm diesen Zaubertrank und war wochenlang krank, aber als es mir wieder besser ging, wurde meine Haut rein und mein Körper formte sich und … ich war schön, die Leute waren \emph{nett} zu mir“, ihre Stimme gab nach, „und danach konnte ich meine Schwester nicht mehr hassen, besonders nachdem ich hörte, was die Magie ihr am Ende angetan hatte …“
 
 % “Darling,” Michael said gently, “you got sick, you gained some weight while resting in bed, and your skin cleared up on its own. Or being sick made you change your diet—”
-„Liebling“, sagt Michael sanft, „du wurdest krank, hast durch die Bettruhe ein wenig zugenommen und deine Haut wurde von selbst rein. Oder weil du krank warst, hast du dich anders ernährt—“
+„Liebling“, sagt Michael sanft, „du wurdest krank, hast durch die Bettruhe ein wenig zugenommen und deine Haut wurde von selbst rein. Oder weil du krank warst, hast du dich anders ernährt …“
 
 % “She was a witch,” Petunia repeated. “I saw it.”
-„Sie war eine Hexe“, wiederholte Petunia. „ich habe es gesehen.“
+„Sie war eine Hexe“, wiederholte Petunia. „Ich habe es gesehen.“
 
 % “Petunia,” Michael said. The annoyance was creeping into his voice. “You \emph{know} that can’t be true. Do I really have to explain why?”
 „Petunia“, sagte Michael. Seine Stimme nahm einen leicht genervten Unterton an.
@@ -87,7 +87,7 @@ Petunia brach ab.
 
 % Petunia wrung her hands. She seemed to be on the verge of tears. “My love, I know I can’t win arguments with you, but please, you have to trust me on this—”
 Petunia rang mit den Händen. Sie schien den Tränen nahe zu sein.
-„Schatz, ich weiß, dass ich keine Diskussionen mit dir gewinnen kann, aber bitte vertrau mir hierbei—“
+„Schatz, ich weiß, dass ich keine Diskussionen mit dir gewinnen kann, aber bitte vertrau mir hierbei …“
 
 „\emph{Dad! Mum!}“
 
@@ -105,8 +105,8 @@ Harry atmete tief durch.
 „Also wusste keiner in deiner Familie über Zauberei Bescheid, als Lily ihren Brief bekam. Was hat \emph{euch} überzeugt?“
 
 % “Ah…” Petunia said. “They didn’t just send a letter. They sent a professor from Hogwarts. He—” Petunia’s eyes flicked to Michael. “He showed us some magic.”
-„Ähm…“, sagte Petunia.
-„Sie haben nicht einfach einen Brief geschickt. Sie haben einen Professor von Hogwarts geschickt. Er“, Petunias Augen zuckten zu Michael rüber, „er hat uns etwas Magie vorgeführt.“
+„Ähm …“, sagte Petunia.
+„Sie haben nicht einfach einen Brief geschickt. Sie haben einen Professor von Hogwarts geschickt. Er …“, Petunias Augen zuckten zu Michael rüber, „er hat uns etwas Magie vorgeführt.“
 
 % “Then you don’t have to fight over this,” Harry said firmly. Hoping against hope that this time, just this once, they would listen to him. “If it’s true, we can just get a Hogwarts professor here and see the magic for ourselves, and Dad will admit that it’s true. And if not, then Mum will admit that it’s false. That’s what the experimental method is for, so that we don’t have to resolve things just by arguing.”
 „Dann müsst ihr euch darüber nicht streiten“, sagte Harry fest. Er hoffte, dass sie dieses Mal, nur dieses eine Mal, endlich auf ihn hören würden.
@@ -117,27 +117,27 @@ Der Professor wandte sich ihm zu und sah ihn, herablassend wie immer, an.
 „Ach, nun komm schon, Harry. \emph{Zauberei}? Ist das dein Ernst? Obwohl du sagst, dass dir Rationalität am wichtigsten ist und du so viel darüber liest? Ich hätte nicht gedacht, dass \emph{du} das ernst nehmen würdest, mein Sohn, selbst wenn du erst zehn bist. Zauberei ist so ziemlich die unwissenschaftlichste Sache, die es gibt!“
 
 % Harry’s mouth twisted bitterly. He was treated well, probably better than most genetic fathers treated their own children. Harry had been sent to the best primary schools—and when that didn’t work out, he was provided with tutors from the endless pool of starving students. Always Harry had been encouraged to study whatever caught his attention, bought all the books that caught his fancy, sponsored in whatever maths or science competitions he entered. He was given anything reasonable that he wanted, except, maybe, the slightest shred of respect. A Doctor teaching biochemistry at Oxford could hardly be expected to listen to the advice of a little boy. You would listen to Show Interest, of course; that’s what a Good Parent would do, and so, if you conceived of yourself as a Good Parent, you would do it. But take a ten-year-old \emph{seriously?} Hardly.
-Harrys Mund verzog sich verbittert. Er wurde gut behandelt, vermutlich besser als die meisten Väter ihre leiblichen Kinder behandelten. Harry wurde auf die beste Grundschule geschickt—und als das nicht ausreichte, wurde er mit Tutoren aus dem unerschöpflichen Pool der verarmten Studenten versorgt. Immer wurde er dazu ermutigt sich in seine Interessensgebiete zu vertiefen, alle Bücher, die ihn interessierten, bekam er gekauft, durfte an allen mathematischen oder naturwissenschaftlichen Wettbewerben teilnehmen. Er bekam fast alles, was er begehrte, aber ernst genommen wurde er nicht. Von einem festangestellten Professor, der in Oxford Biochemie lehrte, konnte man wohl kaum erwarten, dass er den Ratschlägen eines kleinen Jungen Gehör schenkte. Natürlich würde er Interesse vortäuschen; so verhielt sich ein Guter Vater nun einmal und wenn man überzeugt war, ein Guter Vater zu sein, dann machte man das halt so. Aber einen Zehnjährigen \emph{ernst nehmen}? Wohl kaum.
+Harrys Mund verzog sich verbittert. Er wurde gut behandelt, vermutlich besser als die meisten Väter ihre leiblichen Kinder behandelten. Harry wurde auf die beste Grundschule geschickt — und als das nicht ausreichte, wurde er mit Tutoren aus dem unerschöpflichen Pool der verarmten Studenten versorgt. Immer wurde er dazu ermutigt sich in seine Interessensgebiete zu vertiefen, alle Bücher, die ihn interessierten, bekam er gekauft, durfte an allen mathematischen oder naturwissenschaftlichen Wettbewerben teilnehmen. Er bekam fast alles, was er begehrte, aber ernst genommen wurde er nicht. Von einem festangestellten Professor, der in Oxford Biochemie lehrte, konnte man wohl kaum erwarten, dass er den Ratschlägen eines kleinen Jungen Gehör schenkte. Natürlich würde er Interesse vortäuschen; so verhielt sich ein Guter Vater nun einmal und wenn man überzeugt war, ein Guter Vater zu sein, dann machte man das halt so. Aber einen Zehnjährigen \emph{ernst nehmen}? Wohl kaum.
 
 % Sometimes Harry wanted to scream at his father.
 Manchmal hätte Harry seinen Vater am liebsten angeschrien.
 
 % “Mum,” Harry said. “If you want to win this argument with Dad, look in chapter two of the first book of the Feynman Lectures on Physics. There’s a quote there about how philosophers say a great deal about what science absolutely requires, and it is all wrong, because the only rule in science is that the final arbiter is observation—that you just have to look at the world and report what you see. Um…off the top of my head I can’t think of where to find something about how it’s an ideal of science to settle things by experiment instead of arguments—”
 „Mum“, sagte Harry.
-„Wenn du diese Diskussion mit Dad gewinnen willst, schlag in Kapitel zwei des ersten Buches von Richard Feynmans ‚Vorlesungen über Physik‘ nach. Dort erklärt er, wie die Philosophen eine ganze Menge darüber gesagt haben, was die Naturwissenschaften unbedingt erfordern, aber dass das alles falsch ist; denn die einzige Regel in den Naturwissenschaften ist, dass letztlich die Beobachtung entscheidet—dass man die Welt nur betrachten muss und beschreiben, was man sieht. Ähm…mir fällt gerade nicht ein, wo man nachschlagen könnte, dass es ein Ideal der Naturwissenschaften ist, Dinge mithilfe von Experimenten zu klären, statt mit Gewalt oder Streit—“%
+„Wenn du diese Diskussion mit Dad gewinnen willst, schlag in Kapitel zwei des ersten Buches von Richard Feynmans ‚Vorlesungen über Physik‘ nach. Dort erklärt er, wie die Philosophen eine ganze Menge darüber gesagt haben, was die Naturwissenschaften unbedingt erfordern, aber dass das alles falsch ist; denn die einzige Regel in den Naturwissenschaften ist, dass letztlich die Beobachtung entscheidet — dass man die Welt nur betrachten muss und beschreiben, was man sieht. Ähm … mir fällt gerade nicht ein, wo man nachschlagen könnte, dass es ein Ideal der Naturwissenschaften ist, Dinge mithilfe von Experimenten zu klären, statt mit Gewalt oder Streit …“%
 \translatorsnote{Richard Feynmans \emph{Vorlesungen über Physik} (meist kurz für \emph{Feynman Lectures} genannt) werden weithin als die besten Einführungsvorlesungen in die Physik betrachtet. Feynman (der 1965 den Physik-Nobelpreis bekam) schafft es, „dem Leser die Augen zu öffnen und den Geist anzuspornen; er eröffnet riesige Ozeane voller Entdeckungen und lässt sie gleichzeitig so erreichbar erscheinen.“ (Zitat von Bart Alder: \url{http://www.feynmanlectures.info/stories.html})\\
 Mehr zu den Feynman Lectures findet man auf Deutsch unter \url{https://de.wikipedia.org/wiki/Feynman-Vorlesungen_\%C3\%BCber_Physik}\\
 Die englischen Feynman Lectures gibt es als öffentliches HTML eBook unter \url{https://www.feynmanlectures.caltech.edu}}
 
 % His mother looked down at him and smiled. “Thank you, Harry. But—” her head rose back up to stare at her husband. “I don’t want to win an argument with your father. I want my husband to, to listen to his wife who loves him, and trust her just this once—”
 Seine Mutter sah zu ihm runter und lächelte.
-„Danke, Harry. Aber“, sie hob den Kopf und sah ihren Gatten an, „ich will keinen Streit mit deinem Vater gewinnen. Ich will, dass mein Mann—dass er seiner Frau, die ihn liebt, zuhört und ihr dieses eine Mal vertraut.“
+„Danke, Harry. Aber …“, sie hob den Kopf und sah ihren Gatten an, „ich will keinen Streit mit deinem Vater gewinnen. Ich will, dass mein Mann — dass er seiner Frau, die ihn liebt, zuhört und ihr dieses eine Mal vertraut.“
 
 % Harry closed his eyes briefly. \emph{Hopeless.} Both of his parents were just hopeless.
 Harry schloss die Augen. \emph{Hoffnungslos}. Seine Eltern waren beide ein hoffnungsloser Fall.
 
 % Now his parents were getting into one of \emph{those} arguments again, one where his mother tried to make his father feel guilty, and his father tried to make his mother feel stupid.
-Jetzt fingen sie wieder mit \emph{diesem} Streit an: Seine Mutter wollte erreichen, dass sein Vater sich schuldig fühlte und sein Vater wollte, dass seine Mutter sich dumm fühlte. Beide versuchten einfach nur zu \emph{gewinnen}, aber keiner schien willig, sich auf einen Versuch zu einigen, mit dem sie die Wahrheit herausfinden könnten.
+Jetzt fingen sie wieder mit \emph{diesem} Streit an: Seine Mutter wollte erreichen, dass sein Vater sich schuldig fühlte, und sein Vater wollte, dass seine Mutter sich dumm fühlte. Beide versuchten einfach nur zu \emph{gewinnen}, aber keiner schien willig, sich auf einen Versuch zu einigen, mit dem sie die Wahrheit herausfinden könnten.
 
 % “I’m going to go to my room,” Harry announced. His voice trembled a little. “Please try not to fight too much about this, Mum, Dad, we’ll know soon enough how it comes out, right?”
 „Ich gehe in mein Zimmer“, kündigte Harry an. Seine Stimme zitterte etwas.
@@ -150,10 +150,10 @@ Jetzt fingen sie wieder mit \emph{diesem} Streit an: Seine Mutter wollte erreich
 Er schloss die Tür hinter sich und versuchte nachzudenken.
 
 % The funny thing was, he \emph{should} have agreed with Dad. No-one had ever seen any evidence of magic, and according to Mum, there was a whole magical world out there. How could anyone keep something like that a secret? More magic? That seemed like a rather suspicious sort of excuse.
-Das Merkwürdige war, dass er \emph{eigentlich} auf Vaters Seite sein sollte. Niemand hatte jemals irgendwelche Hinweise auf Zauberei entdeckt, obwohl seine Mutter behauptete, dass dort draußen eine ganze magische Welt wäre. Wie konnte man so etwas geheim halten? Durch noch mehr Zauberei? Das kam ihm sehr suspekt vor. Außerdem passte Zauberei an sich überhaupt nicht zu den Naturgesetzen, zu einem Universum, das vollkommenen mathematischen Regeln folgte. Harry glaubte nicht, dass sein Vater all das wirklich \emph{verstand}—obwohl der Professor sehr skeptisch erschien, wusste er doch sehr wenig über Rationalität. Vermutlich verspürte sein Vater nur eine instinktive Abneigung gegen das Wort \emph{Zauberei}.
+Das Merkwürdige war, dass er \emph{eigentlich} auf Dads Seite sein sollte. Niemand hatte jemals irgendwelche Hinweise auf Zauberei entdeckt, obwohl seine Mutter behauptete, dass dort draußen eine ganze magische Welt wäre. Wie konnte man so etwas geheim halten? Durch noch mehr Zauberei? Das kam ihm sehr suspekt vor. Außerdem passte Zauberei an sich überhaupt nicht zu den Naturgesetzen, zu einem Universum, das vollkommenen mathematischen Regeln folgte. Harry glaubte nicht, dass sein Vater all das wirklich \emph{verstand} — obwohl der Professor sehr skeptisch erschien, wusste er doch sehr wenig über Rationalität. Vermutlich verspürte sein Vater nur eine instinktive Abneigung gegen das Wort \emph{Zauberei}.
 
 % It should have been a clean case for Mum joking, lying or being insane, in ascending order of awfulness. If Mum had sent the letter herself, that would explain how it arrived at the letterbox without a stamp. A little insanity was far, far less improbable than the universe really working like that.
-Dennoch war dies ein Fall, in dem die instinktive Abscheu seines Vaters auf sicheren Füßen stand. Es sollte doch offensichtlich sein, dass seine Mutter scherzte, log oder verrückt war—nach aufsteigender Schrecklichkeit geordnet. Wenn sie den Brief selbst geschickt hätte, dann würde dies erklären, warum keine Briefmarke auf dem Umschlag klebte. Ein bisschen Wahnsinn war sehr, sehr viel weniger unwahrscheinlich, als dass das Universum tatsächlich solchen Regeln folgte.
+Dennoch war dies ein Fall, in dem die instinktive Abscheu seines Vaters auf sicheren Füßen stand. Es sollte doch offensichtlich sein, dass seine Mutter scherzte, log oder verrückt war — nach aufsteigender Schrecklichkeit geordnet. Wenn sie den Brief selbst geschickt hätte, dann würde dies erklären, warum keine Briefmarke auf dem Umschlag klebte. Ein bisschen Wahnsinn war sehr, sehr viel weniger unwahrscheinlich, als dass das Universum tatsächlich solchen Regeln folgte.
 
 % Except that some part of Harry was utterly convinced that magic was real, and had been since the instant he saw the putative letter from the Hogwarts School of Witchcraft and Wizardry.
 Doch seitdem er den mutmaßlichen Brief der Hogwarts-Schule für Hexerei und Zauberei gesehen hatte, war ein Teil von Harry fest davon überzeugt, dass es Zauberei gab.
@@ -162,7 +162,7 @@ Doch seitdem er den mutmaßlichen Brief der Hogwarts-Schule für Hexerei und Zau
 Harry massierte sich die Schläfen und verzog das Gesicht. \emph{Glaub nicht alles, was du denkst,} so lautete die rationalistische Version des Sprichwortes. Schenke nicht jedem närrischen Gedanken Glauben, der deinem Kopf entspringt.
 
 % But this bizarre certainty…Harry was finding himself just \emph{expecting} that, yes, a Hogwarts professor would show up and wave a wand and magic would come out. The strange certainty was making no effort to guard itself against falsification—wasn’t making excuses in advance for why there wouldn’t be a professor, or the professor would only be able to bend spoons.
-Aber diese bizarre Gewissheit…Harry bemerkte, dass er einfach davon \emph{ausging}, dass ein Professor von Hogwarts auftauchen, seinen Zauberstab schwingen und zaubern würde. Die bizarre Gewissheit versuchte nicht einmal, sich gegen Falsifizierung zu wehren—sie entwickelte keine Erklärungen, warum kein Professor kommen würde oder warum der Professor nur Löffel verbiegen würde.
+Aber diese bizarre Gewissheit … Harry bemerkte, dass er einfach davon \emph{ausging}, dass ein Professor von Hogwarts auftauchen, seinen Zauberstab schwingen und zaubern würde. Die bizarre Gewissheit versuchte nicht einmal, sich gegen Falsifizierung zu wehren — sie entwickelte keine Erklärungen, warum kein Professor kommen würde oder warum der Professor nur Löffel verbiegen würde.
 
 % \emph{Where do you come from, strange little prediction?} Harry directed the thought at his brain. \emph{Why do I believe what I believe?}
 \emph{Woher kommst du, du seltsame, kleine Gewissheit?} Harry richtete den Gedanken direkt an sein Gehirn. \emph{Warum glaube ich das, was ich glaube?}
@@ -188,7 +188,7 @@ Harry zuckte mit den Schultern, nahm ein Blatt liniertes Papier von seinem Tisch
 \letterAddress{Sehr geehrte Stellvertretende Schulleiterin Minerva McGonagall,}
 
 % \letterAddress{Or Whomsoever It May Concern:}
-\letterAddress{Oder wer hierfür zuständig ist:}
+\letterAddress{oder wer hierfür zuständig ist:}
 
 % I recently received your letter of acceptance to Hogwarts, addressed to Mr~H.~Potter. You may not be aware that my genetic parents, James Potter and Lily Potter (formerly Lily Evans) are dead. I was adopted by Lily’s sister, Petunia Evans-Verres, and her husband, Michael Verres-Evans.
 Ich empfing kürzlich Ihr Aufnahmeschreiben, adressiert an Mr~H.~Potter. Es mag Ihnen nicht bewusst sein, dass meine biologischen Eltern, James Potter und Lily Potter (geb. Evans), tot sind. Ich wurde von Lilys Schwester, Petunia Evans-Verres, und ihrem Ehemann, Michael Verres-Evans, adoptiert.
@@ -197,7 +197,7 @@ Ich empfing kürzlich Ihr Aufnahmeschreiben, adressiert an Mr~H.~Potter. Es mag 
 Ich möchte sehr gerne Hogwarts besuchen, vorausgesetzt, dass ein solcher Ort tatsächlich existiert. Nur meine Mutter Petunia sagt, sie wisse um Zauberei, kann diese jedoch selbst nicht anwenden. Mein Vater ist höchst skeptisch. Ich selbst bin mir unsicher. Ich weiß außerdem nicht, wo ich die im Aufnahmeschreiben genannten Bücher und Ausrüstungsgegenstände erwerben kann.
 
 % Mother mentioned that you sent a Hogwarts representative to Lily Potter (then Lily Evans) in order to demonstrate to her family that magic was real, and, I presume, help Lily obtain her school materials. If you could do this for my own family it would be extremely helpful.
-Mutter erwähnte, dass damals zu Lily Potter (zu der Zeit Lily Evans) ein Hogwartsmitarbeiter kam, um ihrer Familie zu demonstrieren, dass Zauberei existiert und, so nehme ich an, um Lily bei der Beschaffung der Schulsachen zu helfen. Wenn Sie für meine Familie das Gleiche tun könnten, wäre dies äußerst hilfreich.
+Mutter erwähnte, dass damals zu Lily Potter (zu der Zeit Lily Evans) ein Hogwartsmitarbeiter kam, um ihrer Familie zu demonstrieren, dass Zauberei existiert, und, so nehme ich an, um Lily bei der Beschaffung der Schulsachen zu helfen. Wenn Sie für meine Familie das Gleiche tun könnten, wäre dies äußerst hilfreich.
 
 % \letterClosing[Sincerely,]{Harry James Potter-Evans-Verres.}
 \letterClosing[Mit freundlichen Grüßen]{Harry James Potter-Evans-Verres.}
@@ -207,17 +207,17 @@ Mutter erwähnte, dass damals zu Lily Potter (zu der Zeit Lily Evans) ein Hogwar
 Harry ergänzte seine Absenderadresse, faltete den Brief und steckte ihn in einen Briefumschlag, den er an Hogwarts adressierte. Nach weiterem Nachdenken holte er eine Kerze und versiegelte den Umschlag mit Wachs, in welches er mit der Spitze seines Taschenmessers die Initialen H.J.P.E.V. einprägte. Wenn er solchem Wahnsinn verfiel, würde er es zumindest stilvoll tun.
 
 % Then he opened his door and went back downstairs. His father was sitting in the living-room and reading a book of higher maths to show how smart he was; and his mother was in the kitchen preparing one of his father’s favourite meals to show how loving she was. It didn’t look like they were talking to one another at all. As scary as arguments could be, \emph{not arguing} was somehow much worse.
-Dann öffnete er seine Zimmertür und ging hinunter. Sein Vater saß im Wohnzimmer und las ein Buch über höhere Mathematik, um zu zeigen, wie klug er war; seine Mutter war in der Küche und kochte ein Leibgericht seines Vaters, um zu zeigen, wie liebevoll sie war. Es sah nicht so aus, als ob sie überhaupt miteinander reden würden. So beängstigend ein Streit auch sein konnte—\emph{nicht streiten} war in gewisser Weise deutlich schlimmer.
+Dann öffnete er seine Zimmertür und ging hinunter. Sein Vater saß im Wohnzimmer und las ein Buch über höhere Mathematik, um zu zeigen, wie klug er war; seine Mutter war in der Küche und kochte ein Leibgericht seines Vaters, um zu zeigen, wie liebevoll sie war. Es sah nicht so aus, als ob sie überhaupt miteinander reden würden. So beängstigend ein Streit auch sein konnte — \emph{nicht streiten} war in gewisser Weise deutlich schlimmer.
 
 % “Mum,” Harry said into the unnerving silence, “I’m going to test the hypothesis. According to your theory, how do I send an owl to Hogwarts?”
 „Mum“, sagte Harry in die angespannte Stille hinein, „ich werde die Hypothese testen. Wie schicke ich Hogwarts gemäß deiner Theorie eine Eule?“
 
 % His mother turned from the kitchen sink to stare at him, looking shocked. “I—I don’t know, I think you just have to own a magic owl.”
 Seine Mutter drehte sich an der Spüle um und sah ihn schockiert an.
-„Ich—ich weiß nicht, ich glaube, man braucht eine magische Eule.“
+„Ich … ich weiß nicht, ich glaube, man braucht eine magische Eule.“
 
 % That should’ve sounded highly suspicious, \emph{oh, so there’s no way to test your theory then,} but the peculiar certainty in Harry seemed willing to stick its neck out even further.
-Das hätte wieder sein Misstrauen wecken müssen—\emph{oh, also kann man deine Theorie nicht überprüfen}—aber die seltsame Gewissheit in Harry schien gewillt, sich noch weiter hervorzutrauen.
+Das hätte wieder sein Misstrauen wecken müssen — \emph{oh, also kann man deine Theorie nicht überprüfen} —, aber die seltsame Gewissheit in Harry schien gewillt, sich noch weiter hervorzutrauen.
 
 % “Well, the letter got here somehow,” Harry said, “so I’ll just wave it around outside and call ‘letter for Hogwarts!’ and see if an owl picks it up. Dad, do you want to come and watch?”
 „Nun, irgendwie ist der Brief hierher gelangt“, sagte Harry, „also werde ich ihn einfach draußen durch die Luft wedeln und ‚Brief an Hogwarts!‘ rufen und dann abwarten, ob eine Eule kommt und ihn holt. Dad, möchtest du zuschauen?“
@@ -229,7 +229,7 @@ Sein Vater schüttelte kurz den Kopf und las weiter. \emph{Natürlich}, dachte H
 Erst als Harry aus der Hintertür auf den Hof stolperte, wurde ihm bewusst, dass er, selbst wenn eine Eule erschien und den Umschlag mitnahm, Schwierigkeiten haben würde, seinen Vater davon zu überzeugen.
 
 % \emph{But—well—that can’t \emph{really} happen, can it? No matter what my brain seems to believe. If an owl really comes down and grabs this envelope, I’m going to have worries a lot more important than what Dad thinks.}
-\emph{Aber—naja—das kann nicht} tatsächlich \emph{passieren, oder? Egal was mein Gehirn glaubt. Wenn wirklich eine Eule kommt und diesen Umschlag nimmt, werde ich viel wichtigere Sorgen haben als die, wie ich es Dad beibringe.}
+\emph{Aber — naja — das kann nicht} tatsächlich \emph{passieren, oder? Egal was mein Gehirn glaubt. Wenn wirklich eine Eule kommt und diesen Umschlag nimmt, werde ich viel wichtigere Sorgen haben als die, wie ich es Dad beibringe.}
 
 % Harry took a deep breath, and raised the envelope into the air.
 Harry atmete tief ein und hob den Briefumschlag hoch in die Luft.
@@ -238,22 +238,22 @@ Harry atmete tief ein und hob den Briefumschlag hoch in die Luft.
 Er schluckte.
 
 % Calling out \emph{Letter for Hogwarts!} while holding an envelope high in the air in the middle of your own back garden was…actually pretty embarrassing, now that he thought about it.
-\emph{Brief an Hogwarts!} zu rufen, während man im eigenen Hinterhof stand und einen Umschlag in die Luft hielt, war…ziemlich peinlich, jetzt wo er darüber nachdachte.
+\emph{Brief an Hogwarts!} zu rufen, während man im eigenen Hinterhof stand und einen Umschlag in die Luft hielt, war … ziemlich peinlich, jetzt wo er darüber nachdachte.
 
 % \emph{No. I’m better than Dad. I will use the scientific method even if it makes me feel stupid.}
 \emph{Nein. Ich bin besser als Dad. Ich werde wissenschaftlich vorgehen, selbst wenn ich mir dabei dumm vorkomme.}
 
 % “Letter—” Harry said, but it actually came out as more of a whispered croak.
-„Brief—“ sagte Harry, aber ihm entwich nur ein geflüstertes Krächzen.
+„Brief …“ sagte Harry, aber ihm entwich nur ein geflüstertes Krächzen.
 
 % Harry steeled his will, and shouted into the empty sky, “\emph{Letter for Hogwarts! Can I get an owl?}”
-Harry nahm seinen Mut zusammen und schrie zum leeren Himmel hinauf, „\shout{Brief an Hogwarts! Kann ich eine Eule dafür bekommen?}“
+Harry nahm seinen Mut zusammen und schrie zum leeren Himmel hinauf: „\shout{Brief an Hogwarts! Kann ich eine Eule dafür bekommen?}“
 
 % “Harry?” asked a bemused woman’s voice, one of the neighbours.
 „Harry?“, fragte eine verwirrte Frauenstimme, eine der Nachbarinnen.
 
 % Harry pulled down his hand like it was on fire and hid the envelope behind his back like it was drug money. His whole face was hot with shame.
-Harry riss seine Hand herunter, als ob er ins Feuer gefasst hätte und versteckte den Briefumschlag hinter seinem Rücken, als ob es Drogengeld wäre. Sein ganzes Gesicht brannte rot vor Scham.
+Harry riss seine Hand herunter, als ob er ins Feuer gefasst hätte, und versteckte den Briefumschlag hinter seinem Rücken, als ob es Drogengeld wäre. Sein ganzes Gesicht brannte rot vor Scham.
 
 % An old woman’s face peered out from above the neighbouring fence, grizzled grey hair escaping from her hairnet. Mrs~Figg, the occasional babysitter. “What are you doing, Harry?”
 Das Gesicht einer alten Frau blickte über den Zaun, wirre graue Haare schauten unter ihrem Haarnetz hervor. Mrs~Figg, die gelegentlich auf ihn aufpasste.
@@ -261,7 +261,7 @@ Das Gesicht einer alten Frau blickte über den Zaun, wirre graue Haare schauten 
 
 % “Nothing,” Harry said in a strangled voice. “Just—testing a really silly theory—”
 „Nichts“, sagte Harry mit zugeschnürter Kehle.
-„Nur—nur eine wirklich lächerliche Theorie testen…“
+„Nur … nur eine wirklich lächerliche Theorie testen …“
 
 % “Did you get your acceptance letter from Hogwarts?”
 „Hast du dein Aufnahmeschreiben von Hogwarts bekommen?“
@@ -271,7 +271,7 @@ Harry erstarrte.
 
 % “Yes,” Harry’s lips said a little while later. “I got a letter from Hogwarts. They say they want my owl by the 31st of July, but—”
 „Ja“, sagten Harrys Lippen, nachdem seine Zunge sich aus der Erstarrung gelöst hatte.
-„Ich habe einen Brief von Hogwarts bekommen. Sie schreiben, dass sie bis zum 31. Juli meine Eule erwarten, aber—“
+„Ich habe einen Brief von Hogwarts bekommen. Sie schreiben, dass sie bis zum 31. Juli meine Eule erwarten, aber …“
 
 % “But you don’t \emph{have} an owl. Poor dear! I can’t imagine \emph{what} someone must have been thinking, sending you just the standard letter.”
 „Aber du \emph{hast} gar keine Eule. Du Armer! Ich kann mir gar nicht vorstellen, \emph{was} die sich dabei nur gedacht haben, dir einfach den Standardbrief zu schicken.“
@@ -280,7 +280,7 @@ Harry erstarrte.
 Ein runzliger Arm streckte sich über den Zaun und öffnete erwartend eine Hand. Harry, der inzwischen kaum noch klar denken konnte, gab ihr den Umschlag.
 
 % “Just leave it to me, dear,” said Mrs~Figg, “and in a jiffy or two I’ll have someone over.”
-„Überlass’ es einfach mir, mein Lieber“, sagte Mrs~Figg, „und ich schicke dir gleich jemanden vorbei.“
+„Überlass es einfach mir, mein Lieber“, sagte Mrs~Figg, „und ich schicke dir gleich jemanden vorbei.“
 
 % And her face disappeared from over the fence.
 Das Gesicht verschwand vom Zaun.


### PR DESCRIPTION
Ich habe einige kleinere Zeichenfehler korrigiert (Vor und nach Auslassungspunkten muss ein Leerzeichen stehen, sofern sie nicht den fehlenden Teil eines Worts markieren, vor und nach Gedankenstrichen steht ebenfalls ein Leerzeichen und wenn nach dem Einschub durch Gedankenstriche ein Nebensatz steht, der ein Komma verlangt, bleibt dieses nach dem Gedankenstrich erhalten.) Außerdem habe ich die Nutzung der Auslassungspunkte und Gedankenstriche an die deutschen Regeln angepasst und vereinheitlicht. In 153 könnte man überlegen, ob man "Vaters" durch "Dads" ersetzt. Anders als an anderen Textstellen, sind wir hier in Harrys Gedanken, der seinen Vater Dad nennt, und "Vaters" wird wie ein Eigenname gebraucht (anders als an anderen beschreibenden Stellen: sein Vater etc.).